### PR TITLE
Missing "data" in InlineQueryResultDocument.kt

### DIFF
--- a/src/org/marshalov/telekot/client/model/inline/InlineQueryResultDocument.kt
+++ b/src/org/marshalov/telekot/client/model/inline/InlineQueryResultDocument.kt
@@ -11,7 +11,7 @@ import org.marshalov.telekot.client.model.markers.TelegramObject
  * Currently, only .PDF and .ZIP files can be sent using this method.
  */
 @Serializable
-class InlineQueryResultDocument(
+data class InlineQueryResultDocument(
     /**
      * Type of the result, must be document
      */


### PR DESCRIPTION
Fix for #1  - "data class" instead of "class" in InlineQueryResultDocument.